### PR TITLE
Avoid using `Array#reduce`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,10 @@
 'use strict';
 const uniqueRandomArray = require('unique-random-array');
+const {flatZip} = require('flat-zip');
 const femaleDogNames = require('./female-dog-names.json');
 const maleDogNames = require('./male-dog-names.json');
 
-const allDogNames = femaleDogNames.reduce(
-	(allDogNames, femaleDogName, index) => {
-		allDogNames.push(femaleDogName, maleDogNames[index]);
-		return allDogNames;
-	},
-	[]
-);
+const allDogNames = flatZip([femaleDogNames, maleDogNames]);
 
 exports.female = femaleDogNames;
 exports.male = maleDogNames;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"male"
 	],
 	"dependencies": {
+		"flat-zip": "^1.0.1",
 		"meow": "^5.0.0",
 		"unique-random-array": "^2.0.0"
 	},


### PR DESCRIPTION
Applying https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-reduce.md
Using https://github.com/fregante/flat-zip

This way the 2 arrays no longer have to have the same length.